### PR TITLE
Add per-client request rate limiting

### DIFF
--- a/src/main/java/dev/christopherbell/configuration/RateLimitFilter.java
+++ b/src/main/java/dev/christopherbell/configuration/RateLimitFilter.java
@@ -3,6 +3,9 @@ package dev.christopherbell.configuration;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.Bucket4j;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,36 +17,47 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.core.annotation.Order;
 
 /**
- * Simple global rate limiting filter using Bucket4j.
+ * Simple per-client rate limiting filter using Bucket4j.
  */
 @Order(1)
 public class RateLimitFilter extends OncePerRequestFilter {
 
-  private final Bucket bucket;
+  private final Supplier<Bucket> bucketSupplier;
+  private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
 
   /**
    * Creates a filter with default limit of 50 requests per minute.
    */
   public RateLimitFilter() {
-    this(Bucket4j.builder()
+    this(() -> Bucket4j.builder()
         .addLimit(Bandwidth.simple(50, Duration.ofMinutes(1)))
         .build());
   }
 
   /**
-   * Creates a filter with a custom bucket. Intended for testing.
+   * Creates a filter with a custom bucket supplier. Intended for testing.
    */
-  public RateLimitFilter(Bucket bucket) {
-    this.bucket = bucket;
+  public RateLimitFilter(Supplier<Bucket> bucketSupplier) {
+    this.bucketSupplier = bucketSupplier;
   }
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
+    String ip = extractClientIp(request);
+    Bucket bucket = buckets.computeIfAbsent(ip, k -> bucketSupplier.get());
     if (bucket.tryConsume(1)) {
       filterChain.doFilter(request, response);
     } else {
       response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
     }
+  }
+
+  private String extractClientIp(HttpServletRequest request) {
+    String forwarded = request.getHeader("X-Forwarded-For");
+    if (forwarded != null && !forwarded.isBlank()) {
+      return forwarded.split(",")[0].trim();
+    }
+    return request.getRemoteAddr();
   }
 }

--- a/src/test/java/dev/christopherbell/configuration/RateLimitFilterTest.java
+++ b/src/test/java/dev/christopherbell/configuration/RateLimitFilterTest.java
@@ -1,6 +1,7 @@
 package dev.christopherbell.configuration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,6 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -22,11 +24,12 @@ public class RateLimitFilterTest {
 
   @Test
   public void testRateLimitExceeded() throws ServletException, IOException {
-    Bucket bucket = Bucket4j.builder()
+    Supplier<Bucket> supplier = () -> Bucket4j.builder()
         .addLimit(Bandwidth.simple(1, Duration.ofMinutes(1)))
         .build();
-    RateLimitFilter filter = new RateLimitFilter(bucket);
-    HttpServletRequest request = new MockHttpServletRequest();
+    RateLimitFilter filter = new RateLimitFilter(supplier);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("1.1.1.1");
     MockHttpServletResponse response = new MockHttpServletResponse();
     FilterChain chain = mock(FilterChain.class);
 
@@ -38,5 +41,25 @@ public class RateLimitFilterTest {
     MockHttpServletResponse response2 = new MockHttpServletResponse();
     filter.doFilter(request, response2, chain);
     assertEquals(429, response2.getStatus());
+  }
+
+  @Test
+  public void testDifferentIpSeparateBuckets() throws ServletException, IOException {
+    Supplier<Bucket> supplier = () -> Bucket4j.builder()
+        .addLimit(Bandwidth.simple(1, Duration.ofMinutes(1)))
+        .build();
+    RateLimitFilter filter = new RateLimitFilter(supplier);
+    FilterChain chain = mock(FilterChain.class);
+
+    MockHttpServletRequest request1 = new MockHttpServletRequest();
+    request1.setRemoteAddr("1.1.1.1");
+    filter.doFilter(request1, new MockHttpServletResponse(), chain);
+
+    MockHttpServletRequest request2 = new MockHttpServletRequest();
+    request2.setRemoteAddr("2.2.2.2");
+    filter.doFilter(request2, new MockHttpServletResponse(), chain);
+
+    verify(chain, times(2))
+        .doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class));
   }
 }


### PR DESCRIPTION
## Summary
- rate-limit incoming requests by client IP using Bucket4j
- cover rate limit and separate buckets with tests

## Testing
- `bash gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6895248366488330a8c6b2189e9438ba