### PR TITLE
Add request size limit filter

### DIFF
--- a/src/main/java/dev/christopherbell/configuration/RequestSizeLimitFilter.java
+++ b/src/main/java/dev/christopherbell/configuration/RequestSizeLimitFilter.java
@@ -1,0 +1,45 @@
+package dev.christopherbell.configuration;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Filter that rejects requests exceeding a configured maximum size.
+ */
+public class RequestSizeLimitFilter extends OncePerRequestFilter {
+
+  private final long maxSizeBytes;
+
+  /**
+   * Creates a filter with a default limit of 1MB.
+   */
+  public RequestSizeLimitFilter() {
+    this(1_000_000L);
+  }
+
+  /**
+   * Creates a filter with a custom size limit. Intended for testing or configuration.
+   *
+   * @param maxSizeBytes maximum allowed request size in bytes
+   */
+  public RequestSizeLimitFilter(long maxSizeBytes) {
+    this.maxSizeBytes = maxSizeBytes;
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    long contentLength = request.getContentLengthLong();
+    if (contentLength > maxSizeBytes) {
+      response.setStatus(HttpStatus.PAYLOAD_TOO_LARGE.value());
+      return;
+    }
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/dev/christopherbell/configuration/SecurityConfig.java
+++ b/src/main/java/dev/christopherbell/configuration/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import dev.christopherbell.configuration.RateLimitFilter;
 import dev.christopherbell.configuration.JwtAuthenticationFilter;
+import dev.christopherbell.configuration.RequestSizeLimitFilter;
 
 @Configuration
 @EnableMethodSecurity
@@ -44,7 +45,8 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http,
       RateLimitFilter rateLimitFilter,
-      JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+      JwtAuthenticationFilter jwtAuthenticationFilter,
+      RequestSizeLimitFilter requestSizeLimitFilter) throws Exception {
     return http
         // Disable CSRF for APIs (use with care)
         .csrf(AbstractHttpConfigurer::disable)
@@ -58,6 +60,7 @@ public class SecurityConfig {
         // Add rate limiting and JWT authentication filters
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(rateLimitFilter, JwtAuthenticationFilter.class)
+        .addFilterBefore(requestSizeLimitFilter, RateLimitFilter.class)
         
         // Build the SecurityFilterChain
         .build();
@@ -71,6 +74,11 @@ public class SecurityConfig {
   @Bean
   public JwtAuthenticationFilter jwtAuthenticationFilter() {
     return new JwtAuthenticationFilter(createSkipMatchers(PUBLIC_URLS));
+  }
+
+  @Bean
+  public RequestSizeLimitFilter requestSizeLimitFilter() {
+    return new RequestSizeLimitFilter();
   }
 
   @Bean

--- a/src/test/java/dev/christopherbell/configuration/RequestSizeLimitFilterTest.java
+++ b/src/test/java/dev/christopherbell/configuration/RequestSizeLimitFilterTest.java
@@ -1,0 +1,46 @@
+package dev.christopherbell.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class RequestSizeLimitFilterTest {
+
+  @Test
+  public void rejectsLargeRequest() throws ServletException, IOException {
+    RequestSizeLimitFilter filter = new RequestSizeLimitFilter(10);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(new byte[20]);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    filter.doFilter(request, response, chain);
+
+    assertEquals(413, response.getStatus());
+    verify(chain, times(0)).doFilter(request, response);
+  }
+
+  @Test
+  public void allowsSmallRequest() throws ServletException, IOException {
+    RequestSizeLimitFilter filter = new RequestSizeLimitFilter(10);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(new byte[5]);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    filter.doFilter(request, response, chain);
+
+    assertEquals(200, response.getStatus());
+    verify(chain, times(1)).doFilter(request, response);
+  }
+}


### PR DESCRIPTION
## Summary
- limit incoming request payloads to 1MB by default
- wire request size filter into security configuration
- add unit tests for request size filtering

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68952d41d7c883308461be9dedb20505